### PR TITLE
Replace `list.concat` with `list.flatten`

### DIFF
--- a/src/webls/atom.gleam
+++ b/src/webls/atom.gleam
@@ -319,7 +319,7 @@ pub fn with_entry_updated(entry: AtomEntry, updated: Time) -> AtomEntry {
 }
 
 pub fn with_entry_authors(entry: AtomEntry, authors: List(Person)) -> AtomEntry {
-  AtomEntry(..entry, authors: list.concat([entry.authors, authors]))
+  AtomEntry(..entry, authors: list.flatten([entry.authors, authors]))
 }
 
 pub fn with_entry_content(entry: AtomEntry, content: Text) -> AtomEntry {
@@ -338,7 +338,7 @@ pub fn with_entry_categories(
   entry: AtomEntry,
   categories: List(Category),
 ) -> AtomEntry {
-  AtomEntry(..entry, categories: list.concat([entry.categories, categories]))
+  AtomEntry(..entry, categories: list.flatten([entry.categories, categories]))
 }
 
 pub fn with_entry_contributors(
@@ -347,7 +347,7 @@ pub fn with_entry_contributors(
 ) -> AtomEntry {
   AtomEntry(
     ..entry,
-    contributors: list.concat([entry.contributors, contributors]),
+    contributors: list.flatten([entry.contributors, contributors]),
   )
 }
 
@@ -368,7 +368,7 @@ pub fn with_feed_author(feed: AtomFeed, author: Person) -> AtomFeed {
 }
 
 pub fn with_feed_authors(feed: AtomFeed, authors: List(Person)) -> AtomFeed {
-  AtomFeed(..feed, authors: list.concat([feed.authors, authors]))
+  AtomFeed(..feed, authors: list.flatten([feed.authors, authors]))
 }
 
 pub fn with_feed_link(feed: AtomFeed, link: Link) -> AtomFeed {
@@ -383,7 +383,7 @@ pub fn with_feed_categories(
   feed: AtomFeed,
   categories: List(Category),
 ) -> AtomFeed {
-  AtomFeed(..feed, categories: list.concat([feed.categories, categories]))
+  AtomFeed(..feed, categories: list.flatten([feed.categories, categories]))
 }
 
 pub fn with_feed_contributor(feed: AtomFeed, contributor: Person) -> AtomFeed {
@@ -394,7 +394,10 @@ pub fn with_feed_contributors(
   feed: AtomFeed,
   contributors: List(Person),
 ) -> AtomFeed {
-  AtomFeed(..feed, contributors: list.concat([feed.contributors, contributors]))
+  AtomFeed(
+    ..feed,
+    contributors: list.flatten([feed.contributors, contributors]),
+  )
 }
 
 pub fn with_feed_generator(feed: AtomFeed, generator: Generator) -> AtomFeed {
@@ -422,7 +425,7 @@ pub fn with_feed_entry(feed: AtomFeed, entry: AtomEntry) -> AtomFeed {
 }
 
 pub fn with_feed_entries(feed: AtomFeed, entries: List(AtomEntry)) -> AtomFeed {
-  AtomFeed(..feed, entries: list.concat([feed.entries, entries]))
+  AtomFeed(..feed, entries: list.flatten([feed.entries, entries]))
 }
 
 // Types ----------------------------------------------------------------------

--- a/src/webls/robots.gleam
+++ b/src/webls/robots.gleam
@@ -40,7 +40,7 @@ pub fn with_config_robots(
   config: RobotsConfig,
   robots: List(Robot),
 ) -> RobotsConfig {
-  RobotsConfig(..config, robots: list.concat([config.robots, robots]))
+  RobotsConfig(..config, robots: list.flatten([config.robots, robots]))
 }
 
 /// Adds a robot to the robots config
@@ -55,7 +55,7 @@ pub fn robot(user_agent: String) -> Robot {
 
 /// Adds a list of allowed routes to the robot policy
 pub fn with_robot_allowed_routes(robot: Robot, routes: List(String)) -> Robot {
-  Robot(..robot, allowed_routes: list.concat([robot.allowed_routes, routes]))
+  Robot(..robot, allowed_routes: list.flatten([robot.allowed_routes, routes]))
 }
 
 /// Adds a allowed route to the robot policy
@@ -67,7 +67,7 @@ pub fn with_robot_allowed_route(robot: Robot, route: String) -> Robot {
 pub fn with_robot_disallowed_routes(robot: Robot, routes: List(String)) -> Robot {
   Robot(
     ..robot,
-    disallowed_routes: list.concat([robot.disallowed_routes, routes]),
+    disallowed_routes: list.flatten([robot.disallowed_routes, routes]),
   )
 }
 

--- a/src/webls/rss.gleam
+++ b/src/webls/rss.gleam
@@ -321,7 +321,7 @@ pub fn with_channel_categories(
 ) -> RssChannel {
   RssChannel(
     ..channel,
-    categories: list.concat([channel.categories, categories]),
+    categories: list.flatten([channel.categories, categories]),
   )
 }
 
@@ -388,7 +388,7 @@ pub fn with_channel_items(
   channel: RssChannel,
   items: List(RssItem),
 ) -> RssChannel {
-  RssChannel(..channel, items: list.concat([channel.items, items]))
+  RssChannel(..channel, items: list.flatten([channel.items, items]))
 }
 
 /// Adds a RSS item to the RSS channel

--- a/src/webls/sitemap.gleam
+++ b/src/webls/sitemap.gleam
@@ -62,7 +62,7 @@ pub fn sitemap(url: String) -> Sitemap {
 
 /// Adds a list of sitemap items to the sitemap
 pub fn with_sitemap_items(sitemap: Sitemap, items: List(SitemapItem)) -> Sitemap {
-  Sitemap(..sitemap, items: list.concat([sitemap.items, items]))
+  Sitemap(..sitemap, items: list.flatten([sitemap.items, items]))
 }
 
 /// Adds a sitemap item to the sitemap


### PR DESCRIPTION
Considering [`list.concat` seems to have been deprecated and later on removed, in favor of `list.flatten`](https://github.com/gleam-lang/stdlib/commit/c5d0edeaf6edd3280883497d931bdae8aa88afa5#diff-719ddbceb278b5e0028387f0387cf030bca3c167416cc4a2160cd4b4a87e4241L693-L698), I have adjusted `webls` to reflect this change. 

Behaviour seems unchanged, and the docs also state [is is "the same"](https://hexdocs.pm/gleam_stdlib/gleam/list.html#flatten) as `list.concat`.

This was just a simple grep replace, I left the rest of the code unchanged.