### PR TITLE
fix: use RFC 822 date format for RSS pubDate instead of RFC 3339

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -8,6 +8,7 @@ repository = { type = "github", user = "versecafe", repo = "webls" }
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
 gleam_time = ">= 1.6.0 and < 2.0.0"
+gtempo = ">= 7.2.4 and < 8.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,9 +3,11 @@
 
 packages = [
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.68.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F7FAEBD8EF260664E86A46C8DBA23508D1D11BB3BCC6EE1B89B3BC3E5C83FF1E" },
   { name = "gleam_time", version = "1.6.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "0DF3834D20193F0A38D0EB21F0A78D48F2EC276C285969131B86DF8D4EF9E762" },
   { name = "gleeunit", version = "1.9.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "DA9553CE58B67924B3C631F96FE3370C49EB6D6DC6B384EC4862CC4AAA718F3C" },
+  { name = "gtempo", version = "7.2.4", build_tools = ["gleam"], requirements = ["gleam_regexp", "gleam_stdlib", "gleam_time"], otp_app = "gtempo", source = "hex", outer_checksum = "997964753BB7E9D9EA7023B9DB401871410D17C8ED8AC897CB9F7BFC33B277ED" },
   { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
 ]
 
@@ -13,4 +15,5 @@ packages = [
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleam_time = { version = ">= 1.6.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
+gtempo = { version = ">= 7.2.4 and < 8.0.0" }
 simplifile = { version = ">= 2.3.2 and < 3.0.0" }

--- a/src/webls/rss.gleam
+++ b/src/webls/rss.gleam
@@ -2,8 +2,9 @@ import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
-import gleam/time/calendar
 import gleam/time/timestamp.{type Timestamp}
+import tempo
+import tempo/datetime
 
 // Stringify ------------------------------------------------------------------
 
@@ -56,15 +57,13 @@ fn rss_channel_to_string(channel: RssChannel) -> String {
   }
   <> case channel.pub_date {
     Some(pub_date) ->
-      "<pubDate>"
-      <> pub_date |> timestamp.to_rfc3339(calendar.utc_offset)
-      <> "</pubDate>\n"
+      "<pubDate>" <> pub_date |> timestamp_to_rfc822 <> "</pubDate>\n"
     _ -> ""
   }
   <> case channel.last_build_date {
     Some(last_build_date) ->
       "<lastBuildDate>"
-      <> last_build_date |> timestamp.to_rfc3339(calendar.utc_offset)
+      <> last_build_date |> timestamp_to_rfc822
       <> "</lastBuildDate>\n"
     _ -> ""
   }
@@ -199,9 +198,7 @@ fn rss_item_to_string(item: RssItem) -> String {
   }
   <> case item.pub_date {
     Some(pub_date) ->
-      "<pubDate>"
-      <> pub_date |> timestamp.to_rfc3339(calendar.utc_offset)
-      <> "</pubDate>\n"
+      "<pubDate>" <> pub_date |> timestamp_to_rfc822 <> "</pubDate>\n"
     _ -> ""
   }
   <> item.categories
@@ -237,6 +234,13 @@ fn rss_item_to_string(item: RssItem) -> String {
     _ -> ""
   }
   <> "</item>"
+}
+
+/// Converts a timestamp to an RFC 822 date string as required by the RSS 2.0 spec
+fn timestamp_to_rfc822(ts: Timestamp) -> String {
+  ts
+  |> datetime.from_timestamp
+  |> datetime.format(tempo.HTTP)
 }
 
 fn weekday_to_string(weekday: Weekday) -> String {

--- a/test/fixtures/rss.xml
+++ b/test/fixtures/rss.xml
@@ -10,7 +10,7 @@
 <title>Gleam 1.0</title>
 <description>Gleam 1.0 is here!</description>
 <link>https://gleam.run/blog/gleam-1.0</link>
-<pubDate>2024-08-11T20:22:50.481Z</pubDate>
+<pubDate>Sun, 11 Aug 2024 20:22:50 GMT</pubDate>
 <guid isPermaLink="false">gleam 1.0</guid>
 </item>
 <item>


### PR DESCRIPTION
The RSS 2.0 spec requires dates in RFC 822 format (e.g., "Sun, 11 Aug 2024 20:22:50 GMT") but the serializer was outputting RFC 3339 format. Use gtempo's HTTP formatter to produce the correct format.

https://www.rssboard.org/rss-2-0-1